### PR TITLE
Added chown note for Mac

### DIFF
--- a/docs/days/day-1.md
+++ b/docs/days/day-1.md
@@ -61,7 +61,7 @@ After that create Symfony project in `tmp` _(temporary)_ folder, copy it to your
 composer create-project symfony/website-skeleton:4.2.* /tmp/jobeet/
 cp -aR /tmp/jobeet/. .
 exit;
-sudo chown -R $USER:$USER .
+sudo chown -R $USER:$USER .  # if you're on a Mac, use $USER:staff instead
 ```
 
 We install into `tmp` directory and copy then to proper one, because `create-project` command requires target folder to be empty, but in project’s folder we already have docker files.


### PR DESCRIPTION
`chown -R $USER:$USER .` on a Mac returns 'Illegal group name'