### PR TITLE
Added a $ sign front of sudo chown command!

### DIFF
--- a/docs/days/day-1.md
+++ b/docs/days/day-1.md
@@ -63,7 +63,7 @@ After that create Symfony project in `tmp` _(temporary)_ folder, copy it to your
 composer create-project symfony/website-skeleton:4.2.* /tmp/jobeet/
 cp -aR /tmp/jobeet/. .
 exit;
-sudo chown -R $USER:$USER .  # if you're on a Mac, use $USER:staff instead
+sudo chown -R $USER:$USER .  # if you're on a Mac, use $USER:$staff instead
 ```
 
 We install into `tmp` directory and copy then to proper one, because `create-project` command requires target folder to be empty, but in project’s folder we already have docker files.


### PR DESCRIPTION
as a beginner in I was confused as to how this worked and first few times the sudo chown didn't work until I added $ sign front of staff. It'd be helpful to those who's going to come after me and be a mac user. 
sudo chown -R $USER:$staff .    \\ for mac user